### PR TITLE
CSI translation for in-tree volumes

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -383,6 +383,7 @@ type Spec struct {
 	Volume           *v1.Volume
 	PersistentVolume *v1.PersistentVolume
 	ReadOnly         bool
+	InlineVolume     bool
 }
 
 // Name returns the name of either Volume or PersistentVolume, one of which must not be nil.

--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -25,6 +25,11 @@ type InTreePlugin interface {
 	// parameters and translates them to a set of parameters consumable by CSI plugin
 	TranslateInTreeStorageClassParametersToCSI(scParameters map[string]string) (map[string]string, error)
 
+	// TranslateInTreeVolumeToCSI takes a inline volume and will translate
+	// the in-tree volume source to a CSIPersistentVolumeSource
+	// A PV object containing the CSIPersistentVolumeSource in it's spec is returned
+	TranslateInTreeVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, error)
+
 	// TranslateInTreePVToCSI takes a persistent volume and will translate
 	// the in-tree source to a CSI Source. The input persistent volume can be modified
 	TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error)
@@ -34,9 +39,13 @@ type InTreePlugin interface {
 	// by the `Driver` field in the CSI Source. The input PV object can be modified
 	TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error)
 
-	// CanSupport tests whether the plugin supports a given volume
+	// CanSupport tests whether the plugin supports a given persistent volume
 	// specification from the API.
 	CanSupport(pv *v1.PersistentVolume) bool
+
+	// CanSupport tests whether the plugin supports a given inline volume
+	// specification from the API.
+	CanSupportInline(vol *v1.Volume) bool
 
 	// GetInTreePluginName returns the in-tree plugin name this migrates
 	GetInTreePluginName() string


### PR DESCRIPTION
A very preliminary version of the CSI translation work for in-tree volumes. This is to make sure my thinking is in the right track.

For GCE PD CSI translation, the ID generation will require access to the labels for the volumes which are not available through labels (as in-tree volumes do not have labels). So we may need to query the cloud to get the labels which may increase time required to provision due to additional cloud API calls. 

For the other CSI drivers, it seems the ID generation (based on specific labels) is not necessary and the name appears to be enough.

/cc @davidz627 @msau42 @leakingtapan